### PR TITLE
Add addFriend and deleteFriend resolvers

### DIFF
--- a/src/models/User.model.ts
+++ b/src/models/User.model.ts
@@ -5,6 +5,7 @@ const UserSchema = new mongoose.Schema({
   password: String,
   phoneNumber: String,
   email: String,
+  friends: [String],
 });
 
 const User = mongoose.model("User", UserSchema);

--- a/src/resolvers/addFriend.resolver.ts
+++ b/src/resolvers/addFriend.resolver.ts
@@ -1,0 +1,36 @@
+import { UserInputError } from "apollo-server-core";
+import { UserModel } from "../models";
+import { ResolverContext } from "../types";
+
+export default async (
+  _: any,
+  { friendId }: { friendId: string },
+  context: ResolverContext
+) => {
+  const { id, message } = context;
+  if (!id) {
+    throw new UserInputError(message);
+  }
+
+  const user = await UserModel.findById(id);
+  if (!user) {
+    throw new UserInputError("User not found");
+  }
+
+  const friend = await UserModel.findById(friendId);
+  if (!friend) {
+    throw new UserInputError("Friend not found");
+  }
+
+  const alreadyHasThisFriend = user.friends.some(
+    (friend: string) => friendId === friend
+  );
+  if (alreadyHasThisFriend) {
+    throw new UserInputError("Already has this friend");
+  }
+
+  user.friends.push(friendId);
+  await user.save();
+
+  return true;
+};

--- a/src/resolvers/deleteFriend.resolver.ts
+++ b/src/resolvers/deleteFriend.resolver.ts
@@ -1,0 +1,31 @@
+import { UserInputError } from "apollo-server-core";
+import { UserModel } from "../models";
+import { ResolverContext } from "../types";
+
+export default async (
+  _: any,
+  { friendId }: { friendId: string },
+  context: ResolverContext
+) => {
+  const { id, message } = context;
+  if (!id) {
+    throw new UserInputError(message);
+  }
+
+  const user = await UserModel.findById(id);
+  if (!user) {
+    throw new UserInputError("User not found");
+  }
+
+  const alreadyHasThisFriend = user.friends.some(
+    (friend: string) => friendId === friend
+  );
+  if (!alreadyHasThisFriend) {
+    throw new UserInputError("You don't have this friend");
+  }
+
+  user.friends = user.friends.filter((friend: string) => friendId !== friend);
+  await user.save();
+
+  return true;
+};

--- a/src/resolvers/deleteUser.resolver.ts
+++ b/src/resolvers/deleteUser.resolver.ts
@@ -1,0 +1,25 @@
+import bcrypt from "bcryptjs";
+import { UserInputError } from "apollo-server-core";
+import { UserModel } from "../models";
+import { ResolverContext } from "../types";
+
+export default async (
+  _: any,
+  { password }: { password: string },
+  context: ResolverContext
+) => {
+  const { id, message } = context;
+  if (!id) {
+    throw new UserInputError(message);
+  }
+
+  const existedUser = await UserModel.findById(id);
+  const validedUser = await bcrypt.compare(password, existedUser.password);
+  if (!validedUser) {
+    throw new UserInputError("Wrong password");
+  }
+
+  await existedUser.remove();
+
+  return true;
+};

--- a/src/resolvers/editUser.resolver.ts
+++ b/src/resolvers/editUser.resolver.ts
@@ -1,0 +1,31 @@
+import { UserInputError } from "apollo-server-core";
+import { UserModel } from "../models";
+import { ResolverContext, UserMutationArgs } from "../types";
+
+export default async (
+  _: any,
+  { user }: UserMutationArgs,
+  context: ResolverContext
+) => {
+  const { phoneNumber, email } = user;
+  if (
+    !phoneNumber ||
+    !email ||
+    phoneNumber.trim().length < 6 ||
+    email.trim().length < 6
+  ) {
+    throw new UserInputError("Invalid argument value");
+  }
+
+  const { id, message } = context;
+  if (!id) {
+    throw new UserInputError(message);
+  }
+
+  const updatedUser = await UserModel.findByIdAndUpdate(id, { ...user });
+  if (!updatedUser) {
+    throw new UserInputError("User not found");
+  }
+
+  return true;
+};

--- a/src/resolvers/login.resolver.ts
+++ b/src/resolvers/login.resolver.ts
@@ -1,0 +1,34 @@
+import { UserInputError } from "apollo-server-core";
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
+
+import { UserModel } from "../models";
+import { AuthMutationArgs } from "../types";
+import { env } from "../utils";
+
+export default async (_: any, { user }: AuthMutationArgs) => {
+  const { username, password } = user;
+  if (
+    !username ||
+    !password ||
+    username.toLowerCase().trim().length < 6 ||
+    password.trim().length < 6
+  ) {
+    throw new UserInputError("Invalid argument value");
+  }
+
+  const existedUser = await UserModel.findOne({ username });
+  if (!existedUser) {
+    throw new UserInputError("Wrong username");
+  }
+
+  const validedUser = await bcrypt.compare(password, existedUser.password);
+  if (!validedUser) {
+    throw new UserInputError("Wrong password");
+  }
+
+  const accessToken = jwt.sign({ id: existedUser.id }, env.JWT_SECRET!, {
+    expiresIn: "1h",
+  });
+  return { accessToken };
+};

--- a/src/resolvers/register.resolver.ts
+++ b/src/resolvers/register.resolver.ts
@@ -1,0 +1,39 @@
+import { UserInputError } from "apollo-server-core";
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
+
+import { UserModel } from "../models";
+import { AuthMutationArgs } from "../types";
+import { env } from "../utils";
+
+export default async (_: any, { user }: AuthMutationArgs) => {
+  const { username, password } = user;
+
+  if (
+    !username ||
+    !password ||
+    username.toLowerCase().trim().length < 6 ||
+    password.trim().length < 6
+  ) {
+    throw new UserInputError("Invalid argument value");
+  }
+
+  const existedUser = await UserModel.findOne({ username });
+  if (existedUser) {
+    throw new UserInputError("User existed");
+  }
+
+  const newUser = await UserModel.create({
+    ...user,
+    password: await bcrypt.hash(password, 10),
+  });
+  if (!newUser) {
+    throw new Error("Something went wrong, please try again");
+  }
+
+  const accessToken = jwt.sign({ id: newUser.id }, env.JWT_SECRET!, {
+    expiresIn: "1h",
+  });
+
+  return { accessToken };
+};

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -2,15 +2,22 @@ import { gql } from "apollo-server-core";
 
 const typeDefs = gql`
   type Query {
+    "For testing purposes only"
     users: [User]
-    user: User
+
+    "For testing purposes only"
     deleteAllUsers: String
+
+    "Get user information using accessToken attached in the headers"
+    user: User
   }
 
   type User {
+    id: ID
     username: String
     phoneNumber: String
     email: String
+    friends: [String]
   }
 
   type Mutation {
@@ -19,6 +26,9 @@ const typeDefs = gql`
 
     editUser(user: EditUserInput): Boolean
     deleteUser(password: String): Boolean
+
+    addFriend(friendId: String): Boolean
+    deleteFriend(friendId: String): Boolean
   }
 
   type AuthResponse {


### PR DESCRIPTION
# Changes
- Add addFriend and deleteFriend resolvers
- Add `friends` property to UserModel
- Move resolvers to separated files 
# How to test this
- Using Postman or [Studio](https://studio.apollographql.com/sandbox/explorer)
- `Login` 
![image](https://user-images.githubusercontent.com/87371950/182899678-a5973839-5f58-421b-ab0c-d2eeeb8cefc3.png)
- Attach the received `accessToken` into headers
![image](https://user-images.githubusercontent.com/87371950/182900625-3098a2fa-359f-484a-864a-7aba1aba1363.png)
- Change the token, [make sure to keep the WHITESPACE](https://swagger.io/docs/specification/authentication/bearer-authentication/) - then hit Save
![image](https://user-images.githubusercontent.com/87371950/182902294-4dc45353-4a68-4082-bb51-09fd569dc1cc.png)
- Now you should be able to use all the queries and mutations, for example: 
![image](https://user-images.githubusercontent.com/87371950/182902688-750e4694-ec14-4e5e-8767-f7dc27d52cc0.png)
- The response (if successfully) should be like:
![image](https://user-images.githubusercontent.com/87371950/182903048-7baef3a0-e49f-4831-b9fe-e1d6b0465e40.png)

